### PR TITLE
Fix crash when started with nonexistent config file (#14).

### DIFF
--- a/src/clamfs.cxx
+++ b/src/clamfs.cxx
@@ -997,7 +997,10 @@ int main(int argc, char *argv[])
     /*
      * Check if we have one argument (other arguments are assumed RLog related)
      */
-    if (argc < 2) {
+    if ((argc < 2) ||
+        ((argc > 1) &&
+         ((strncmp(argv[1], "-h", strlen("-h")) == 0) ||
+          (strncmp(argv[1], "--help", strlen("--help")) == 0)))) {
         rLog(Warn, "ClamFS need to be invoked with one parameter - location of configuration file");
         rLog(Warn, "Example: %s /etc/clamfs/home.xml", argv[0]);
         return EXIT_FAILURE;

--- a/src/config.cxx
+++ b/src/config.cxx
@@ -41,7 +41,11 @@ ConfigParserXML::ConfigParserXML(const char *filename) {
     parser.setFeature(XMLReader::FEATURE_NAMESPACES, true);
     parser.setFeature(XMLReader::FEATURE_NAMESPACE_PREFIXES, true);
     parser.setContentHandler(&handler);
-    parser.parse(filename);
+    try {
+       parser.parse(filename);
+    } catch (Poco::Exception &e) {
+       rLog(Warn, e.displayText().c_str());
+    }
 #ifndef NDEBUG
     cout << "--- end of xml dump ---" << endl;
 #endif

--- a/src/config.hxx
+++ b/src/config.hxx
@@ -42,6 +42,7 @@
 #include <dmalloc.h>
 #endif
 
+#include "rlog.hxx"
 #include "utils.hxx"
 
 namespace clamfs {
@@ -60,6 +61,13 @@ using namespace tr1;
    \brief Poco library XML parser namespace
 */
 using namespace Poco::XML;
+
+/*!\namespace rlog
+   \brief rLog library namespace
+*/
+using namespace rlog;
+
+extern RLogChannel *Warn;
 
 /*!\enum acl_item
    \brief Enumeration of Access List Items


### PR DESCRIPTION
Handle starting without arguments, with -h/--help, with nonexistent config
file and with config file with errors.