### PR TITLE
Update default configuration to more sane values.

### DIFF
--- a/doc/clamfs.xml
+++ b/doc/clamfs.xml
@@ -32,7 +32,7 @@
          This option can speed up access to large files, as they will be
          never scanned. On the other hand attacker can append long portion
          of junk at the end of file to make it big enough to be omitted. -->
-    <file maximal-size="2097152" /> <!-- 2MiB -->
+    <file maximal-size="67108864" /> <!-- 64MiB -->
 
     <!-- Whitelisted files are never scanned.
          This can speed up access to some files, but be careful with this,
@@ -95,10 +95,10 @@
     </blacklist>
 
     <!-- How many entries to keep in cache and for how long -->
-    <cache entries="16384" expire="10800000" /> <!-- time in ms, 3h -->
+    <cache entries="65536" expire="10800000" /> <!-- time in ms, 3h -->
 
     <!-- Statistics module keep track of filesystem & memory usage -->
-    <stats memory="yes" atexit="yes" every="3600" /> <!-- time in sec, 1h -->
+    <stats memory="no" atexit="yes" every="3600" /> <!-- time in sec, 1h -->
 
     <!-- Logging method (stdout, syslog or file) -->
     <!-- <log method="stdout" verbose="yes" /> -->

--- a/src/rlog.cxx
+++ b/src/rlog.cxx
@@ -94,7 +94,7 @@ void RLogOpenLogFile(const char *filename) {
     mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
 
     fileLog = open(filename, O_WRONLY | O_CREAT | O_APPEND, mode);
-    if (fileLog > 0) { /* file open succesful */
+    if (fileLog > 0) { /* file open successful */
 #ifndef NDEBUG
         fileLogNode = new StdioNode(fileLog, StdioNode::OutputContext |
         StdioNode::OutputThreadId);


### PR DESCRIPTION
Configuration file was written 10 years ago and looks a bit rusty with
AV engine allowed to san only files smaller than 2 MiB and keeping 16k
entries in cache. Also printing memory stats are no longer of any
interest for most users.

New defaults are as follows:
 - file size limit: 64 MiB
 - cache size limit: 65536 entries
 - mallinfo in stats: disabled