### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ sudo: required
 arch:
   - amd64
   - arm64
+  - ppc64
 
 compiler:
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ sudo: required
 arch:
   - amd64
   - arm64
-  - ppc64
+  - ppc64le
 
 compiler:
   - clang


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3