### PR TITLE
Glibc 2.33 deprecated mallinfo() in favor of mallinfo2()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ AC_FUNC_CLOSEDIR_VOID
 AC_FUNC_LSTAT
 AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK
 AC_FUNC_UTIME_NULL
-AC_CHECK_FUNCS([fchdir fdatasync fork ftruncate fstatat utimensat posix_fallocate copy_file_range lchown memset mkdir mkfifo rmdir setxattr strdup strerror utime mallinfo])
+AC_CHECK_FUNCS([fchdir fdatasync fork ftruncate fstatat utimensat posix_fallocate copy_file_range lchown memset mkdir mkfifo rmdir setxattr strdup strerror utime mallinfo mallinfo2])
 
 # Check for BSD 4.4 / RFC2292 style fd passing
 AC_C_FDPASSING

--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -69,7 +69,19 @@ void Stats::dumpFilesystemStatsToLog() {
 
 void Stats::dumpMemoryStatsToLog() {
     rLog(Info, "--- begin of memory statistics ---");
-#ifdef HAVE_MALLINFO
+#if defined(HAVE_MALLINFO2)
+    struct mallinfo2 mi = mallinfo2();
+    rLog(Info, "Non-mmapped space allocated (arena):         %ld", mi.arena);
+    rLog(Info, "Number of free chunks (ordblks):             %ld", mi.ordblks);
+    rLog(Info, "Number of free fastbin blocks (smblks):      %ld", mi.smblks);
+    rLog(Info, "Number of mmapped regions (hblks):           %ld", mi.hblks);
+    rLog(Info, "Space allocated in mmapped regions (hblkhd): %ld", mi.hblkhd);
+    rLog(Info, "Maximum total allocated space (usmblks):     %ld", mi.usmblks);
+    rLog(Info, "Space in freed fastbin blocks (fsmblks):     %ld", mi.fsmblks);
+    rLog(Info, "Total allocated space (uordblks):            %ld", mi.uordblks);
+    rLog(Info, "Total free space (fordblks):                 %ld", mi.fordblks);
+    rLog(Info, "Top-most, releasable space (keepcost):       %ld", mi.keepcost);
+#elif defined(HAVE_MALLINFO)
     struct mallinfo mi = mallinfo();
     rLog(Info, "Non-mmapped space allocated (arena):         %d", mi.arena);
     rLog(Info, "Number of free chunks (ordblks):             %d", mi.ordblks);


### PR DESCRIPTION
See: https://sourceware.org/pipermail/libc-alpha/2021-February/122207.html