### PR TITLE
Fix mallinfo2() format on 32 bit machines

### DIFF
--- a/src/stats.cxx
+++ b/src/stats.cxx
@@ -71,16 +71,16 @@ void Stats::dumpMemoryStatsToLog() {
     rLog(Info, "--- begin of memory statistics ---");
 #if defined(HAVE_MALLINFO2)
     struct mallinfo2 mi = mallinfo2();
-    rLog(Info, "Non-mmapped space allocated (arena):         %ld", mi.arena);
-    rLog(Info, "Number of free chunks (ordblks):             %ld", mi.ordblks);
-    rLog(Info, "Number of free fastbin blocks (smblks):      %ld", mi.smblks);
-    rLog(Info, "Number of mmapped regions (hblks):           %ld", mi.hblks);
-    rLog(Info, "Space allocated in mmapped regions (hblkhd): %ld", mi.hblkhd);
-    rLog(Info, "Maximum total allocated space (usmblks):     %ld", mi.usmblks);
-    rLog(Info, "Space in freed fastbin blocks (fsmblks):     %ld", mi.fsmblks);
-    rLog(Info, "Total allocated space (uordblks):            %ld", mi.uordblks);
-    rLog(Info, "Total free space (fordblks):                 %ld", mi.fordblks);
-    rLog(Info, "Top-most, releasable space (keepcost):       %ld", mi.keepcost);
+    rLog(Info, "Non-mmapped space allocated (arena):         %zd", mi.arena);
+    rLog(Info, "Number of free chunks (ordblks):             %zd", mi.ordblks);
+    rLog(Info, "Number of free fastbin blocks (smblks):      %zd", mi.smblks);
+    rLog(Info, "Number of mmapped regions (hblks):           %zd", mi.hblks);
+    rLog(Info, "Space allocated in mmapped regions (hblkhd): %zd", mi.hblkhd);
+    rLog(Info, "Maximum total allocated space (usmblks):     %zd", mi.usmblks);
+    rLog(Info, "Space in freed fastbin blocks (fsmblks):     %zd", mi.fsmblks);
+    rLog(Info, "Total allocated space (uordblks):            %zd", mi.uordblks);
+    rLog(Info, "Total free space (fordblks):                 %zd", mi.fordblks);
+    rLog(Info, "Top-most, releasable space (keepcost):       %zd", mi.keepcost);
 #elif defined(HAVE_MALLINFO)
     struct mallinfo mi = mallinfo();
     rLog(Info, "Non-mmapped space allocated (arena):         %d", mi.arena);


### PR DESCRIPTION
The mallinfo2 fields are 'long unsigned int' on 64 bit machines, but only 'unsigned int' on 32 bit machines. Using the '%zd' format handles this for both cases.

This is a fixup of #64 